### PR TITLE
114 call the google street view ımage metadata apı before attempting to fetch an image

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/controller/MetadataTestController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/controller/MetadataTestController.java
@@ -1,0 +1,26 @@
+package ch.uzh.ifi.hase.soprafs25.controller;
+
+import ch.uzh.ifi.hase.soprafs25.service.image.StreetViewMetadataService;
+import org.springframework.web.bind.annotation.*;
+
+// To test real coordinates which give status:OK
+// GET http://localhost:8080/test-metadata?lat=48.8584&lng=2.2945
+
+// To test real coordinates which give status:ZERO_RESULTS
+// GET http://localhost:8080/test-metadata?lat=0.0&lng=-160.0
+
+@RestController
+@RequestMapping("/test-metadata")
+public class MetadataTestController {
+
+    private final StreetViewMetadataService metadataService;
+
+    public MetadataTestController(StreetViewMetadataService metadataService) {
+        this.metadataService = metadataService;
+    }
+
+    @GetMapping
+    public String testMetadata(@RequestParam double lat, @RequestParam double lng) {
+        return metadataService.getStatus(lat, lng);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/StreetViewMetadataService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/StreetViewMetadataService.java
@@ -1,0 +1,47 @@
+package ch.uzh.ifi.hase.soprafs25.service.image;
+
+import ch.uzh.ifi.hase.soprafs25.exceptions.ImageLoadingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class StreetViewMetadataService {
+
+    private static final Logger log = LoggerFactory.getLogger(StreetViewMetadataService.class);
+
+    @Value("${google.maps.api.key}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public String getStatus(double lat, double lng) {
+        String url = UriComponentsBuilder.newInstance()
+                .scheme("https")
+                .host("maps.googleapis.com")
+                .path("/maps/api/streetview/metadata")
+                .queryParam("location", lat + "," + lng)
+                .queryParam("radius", 50000)
+                .queryParam("key", apiKey)
+                .toUriString();
+
+        try {
+            String response = restTemplate.getForObject(url, String.class);
+            JsonNode rootNode = objectMapper.readTree(response);
+            String status = rootNode.path("status").asText();
+
+            log.info("STATUS: {} | Requested metadata URL: https://maps.googleapis.com/maps/api/streetview/metadata?location={},{}&radius=50000", status, lat, lng);
+
+            return status;
+        }
+        catch (Exception e) {
+            throw new ImageLoadingException(e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,4 +14,4 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
 cors.allowed-origins=https://spyquest.whtvr.ch, http://localhost:3000
 
-google.maps.api.key=API_KEY_PLACEHOLDER
+google.maps.api.key=${GOOGLE_MAPS_API_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,5 @@ spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
 cors.allowed-origins=https://spyquest.whtvr.ch, http://localhost:3000
+
+google.maps.api.key=API_KEY_PLACEHOLDER


### PR DESCRIPTION
This PR implements a pre-check mechanism using the Google Street View Metadata API before attempting to fetch an image from the Street View API.

 **Changes Made**

- Created a StreetViewMetadataService to request metadata and validate if an image is available (status: OK)
- Integrated the metadata check into GoogleImageService before fetching images
- Added radius parameter (50,000m) to improve results when metadata returns ZERO_RESULTS
- Added logging for:

        - Requested metadata URLs (API key hidden)
        - Parsed status from metadata response
- Introduced a test controller to verify metadata responses manually (/test-metadata?lat=..&lng=..)
- Replaced exposed API key with API_KEY_PLACEHOLDER in application.properties
- Ensured ImageLoadingException is consistently used when API fails

**Notes**

- The actual API key is no longer committed
- **application.properties should be added to .gitignore or managed via environment variables in the future**