### PR TITLE
fix(cors): add allowed origins to resolve CORS issues in development

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/config/CorsConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/config/CorsConfig.java
@@ -15,6 +15,7 @@ public class CorsConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins(allowedOrigins)
-                .allowedMethods("*");
+                .allowedMethods("*")
+                .allowCredentials(true); 
     }
 }


### PR DESCRIPTION
Added allowCredentials(true) to the CORS config to support authenticated requests with cookies or authorization headers from the frontend. This is necessary when using `credentials: 'include'` in fetch requests.
