### PR TITLE
95 fetch random street view images from the external apı at the start of each round

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/controller/ImageController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/controller/ImageController.java
@@ -7,7 +7,6 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import java.util.concurrent.ThreadLocalRandom;
 
 @RestController
 public class ImageController {
@@ -15,16 +14,14 @@ public class ImageController {
     private final ImageService imageService;
 
     // Change mock to google to use real API
-    public ImageController(@Qualifier("mockImageService") ImageService imageService) {
+    public ImageController(@Qualifier("googleImageService") ImageService imageService) {
         this.imageService = imageService;
     }
 
     @GetMapping(value = "/image", produces = MediaType.IMAGE_JPEG_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public byte[] getImage() {
-        double lat = ThreadLocalRandom.current().nextDouble(-90.0, 90.0); //NOSONAR
-        double lng = ThreadLocalRandom.current().nextDouble(-180.0, 180.0); //NOSONAR
-        return imageService.fetchImage(lat, lng);
+        return imageService.fetchImage();
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/GoogleImageService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/GoogleImageService.java
@@ -12,7 +12,6 @@ import java.util.concurrent.ThreadLocalRandom;
 @Service("googleImageService")
 public class GoogleImageService implements ImageService {
 
-    private static final int MAX_ATTEMPTS = 30;
 
     private final StreetViewMetadataService metadataService;
     private final RestTemplate restTemplate = new RestTemplate();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/GoogleImageService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/GoogleImageService.java
@@ -1,11 +1,37 @@
 package ch.uzh.ifi.hase.soprafs25.service.image;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
 
 @Service("googleImageService")
 public class GoogleImageService implements ImageService {
 
-    @Override
-    public byte[] fetchImage(double lat, double lng) {
-        throw new UnsupportedOperationException("Not implemented yet");
+    private static final String IMAGE_API_URL = "https://maps.googleapis.com/maps/api/streetview";
+    private static final int MAX_ATTEMPTS = 38;
+
+    private final StreetViewMetadataService metadataService;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${google.maps.api.key}")
+    private String apiKey;
+
+    public GoogleImageService(StreetViewMetadataService metadataService) {
+        this.metadataService = metadataService;
+    }
+
+  ImageLoadingException(new Throwable("No StreetView image available after multiple attempts."));
+    }
+
+    private byte[] fetchStreetViewImage(double lat, double lng) {
+        String url = UriComponentsBuilder.fromHttpUrl(IMAGE_API_URL)
+                .queryParam("size", "400x400")
+                .queryParam("location", lat + "," + lng)
+                .queryParam("key", apiKey)
+                .toUriString();
+
+        return restTemplate.getForObject(url, byte[].class);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/ImageService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/ImageService.java
@@ -1,5 +1,5 @@
 package ch.uzh.ifi.hase.soprafs25.service.image;
 
 public interface ImageService {
-    byte[] fetchImage(double lat, double lng);
+    byte[] fetchImage();
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/MockImageService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/MockImageService.java
@@ -10,7 +10,7 @@ import org.springframework.core.io.ClassPathResource;
 public class    MockImageService implements ImageService {
 
     @Override
-    public byte[] fetchImage(double lat, double lng) {
+    public byte[] fetchImage() {
         try {
             // load static image from class path
             ClassPathResource resource = new ClassPathResource("static/mock-image.jpg");

--- a/src/test/java/ch/uzh/ifi/hase/soprafs25/controller/ImageControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs25/controller/ImageControllerTest.java
@@ -12,12 +12,12 @@ public class ImageControllerTest {
     public void testGetImageReturnsBytes() {
         ImageService mockService = mock(ImageService.class);
         byte[] fakeImage = new byte[]{1, 2, 3};
-        when(mockService.fetchImage(anyDouble(), anyDouble())).thenReturn(fakeImage);
+        when(mockService.fetchImage()).thenReturn(fakeImage);
 
         ImageController controller = new ImageController(mockService);
         byte[] response = controller.getImage();
 
         assertArrayEquals(fakeImage, response);
-        verify(mockService).fetchImage(anyDouble(), anyDouble());
+        verify(mockService).fetchImage();
     }
 }


### PR DESCRIPTION
Summary

- Implements fetching random Street View images using Google Maps API.
- Adds logic with metadata validation to avoid invalid coordinates.
- Refactors controller to delegate random location generation to the service.

Changes

- GoogleImageService: generates lat/lng, validates with metadata, fetches image.
- ImageController: simplified to just call fetchImage().
- ImageService: interface updated to remove parameters.
- MockImageService: adjusted to new interface.
- Security fix: safer URL building to prevent CVE-2024-22259.