### PR TITLE
feat: limit API usage with retry logic and handle failures

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/GoogleImageService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/GoogleImageService.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ThreadLocalRandom;
 @Service("googleImageService")
 public class GoogleImageService implements ImageService {
 
+    private static final int MAX_ATTEMPTS = 30;
 
     private final StreetViewMetadataService metadataService;
     private final RestTemplate restTemplate = new RestTemplate();
@@ -25,7 +26,9 @@ public class GoogleImageService implements ImageService {
 
     @Override
     public byte[] fetchImage() {
+        int attempt = 0;
 
+        while (attempt < MAX_ATTEMPTS) {
             double lat = ThreadLocalRandom.current().nextDouble(-90.0, 90.0); //NOSONAR
             double lng = ThreadLocalRandom.current().nextDouble(-180.0, 180.0); //NOSONAR
 
@@ -34,6 +37,9 @@ public class GoogleImageService implements ImageService {
             if ("OK".equals(status)) {
                 return fetchStreetViewImage(lat, lng);
             }
+
+            attempt++;
+        }
 
         throw new ImageLoadingException(new Throwable("No StreetView image available after multiple attempts."));
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/MockImageService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/MockImageService.java
@@ -1,22 +1,22 @@
 package ch.uzh.ifi.hase.soprafs25.service.image;
 
 import ch.uzh.ifi.hase.soprafs25.exceptions.ImageLoadingException;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.io.InputStream;
-import org.springframework.core.io.ClassPathResource;
 
 @Service
-public class    MockImageService implements ImageService {
+public class MockImageService implements ImageService {
 
     @Override
     public byte[] fetchImage() {
         try {
-            // load static image from class path
             ClassPathResource resource = new ClassPathResource("static/mock-image.jpg");
             InputStream inputStream = resource.getInputStream();
             return inputStream.readAllBytes();
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             throw new ImageLoadingException(e);
         }
     }


### PR DESCRIPTION
Adds retry logic and error handling to avoid excessive Google Street View API calls.

Changes

- Retry up to MAX_ATTEMPTS when no valid image is found.
- Check metadata before fetching images.
- Throw ImageLoadingException after retries fail.

Closes #99