### PR TITLE
115 create predefined radial coordinates for the randomization logic

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/controller/ImageController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/controller/ImageController.java
@@ -4,7 +4,9 @@ import ch.uzh.ifi.hase.soprafs25.service.image.ImageService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,8 +22,11 @@ public class ImageController {
 
     @GetMapping(value = "/image", produces = MediaType.IMAGE_JPEG_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public byte[] getImage() {
-        return imageService.fetchImage();
+    public ResponseEntity<?> getImage(@RequestParam(required = false) String location) {
+        byte[] image = (location == null)
+                ? imageService.fetchImage()
+                : imageService.fetchImage(location);
+        return ResponseEntity.ok(image);
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/GoogleImageService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/GoogleImageService.java
@@ -59,5 +59,10 @@ public class GoogleImageService implements ImageService {
 
         return restTemplate.getForObject(uri, byte[].class);
     }
+
+    @Override
+    public byte[] fetchImage(String location) {
+        return fetchImage();
+    }
 }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/ImageService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/ImageService.java
@@ -2,4 +2,5 @@ package ch.uzh.ifi.hase.soprafs25.service.image;
 
 public interface ImageService {
     byte[] fetchImage();
+    byte[] fetchImage(String location); // new method for location base services
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/MockImageService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/image/MockImageService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.io.InputStream;
 
-@Service
+@Service("mockImageService")
 public class MockImageService implements ImageService {
 
     @Override
@@ -15,9 +15,13 @@ public class MockImageService implements ImageService {
             ClassPathResource resource = new ClassPathResource("static/mock-image.jpg");
             InputStream inputStream = resource.getInputStream();
             return inputStream.readAllBytes();
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw new ImageLoadingException(e);
         }
+    }
+
+    @Override
+    public byte[] fetchImage(String location) {
+        return fetchImage();
     }
 }

--- a/src/main/resources/coordinates.json
+++ b/src/main/resources/coordinates.json
@@ -1,0 +1,34 @@
+{
+  "locations": {
+    "europe": {
+      "minLat": 35.0,
+      "maxLat": 71.0,
+      "minLng": -25.0,
+      "maxLng": 40.0
+    },
+    "asia": {
+      "minLat": -10.0,
+      "maxLat": 81.0,
+      "minLng": 25.0,
+      "maxLng": 180.0
+    },
+    "north_america": {
+      "minLat": 5.0,
+      "maxLat": 83.0,
+      "minLng": -168.0,
+      "maxLng": -52.0
+    },
+    "south_america": {
+      "minLat": -56.0,
+      "maxLat": 13.0,
+      "minLng": -81.0,
+      "maxLng": -34.0
+    },
+    "africa": {
+      "minLat": -35.0,
+      "maxLat": 37.0,
+      "minLng": -18.0,
+      "maxLng": 51.0
+    }
+  }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs25/controller/ImageControllerLocationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs25/controller/ImageControllerLocationTest.java
@@ -1,0 +1,39 @@
+package ch.uzh.ifi.hase.soprafs25.controller;
+
+import ch.uzh.ifi.hase.soprafs25.service.image.ImageService;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ImageControllerLocationTest {
+
+    @Test
+    public void testGetImageWithoutLocation() {
+        ImageService mockService = mock(ImageService.class);
+        byte[] fakeImage = new byte[]{10, 20, 30};
+        when(mockService.fetchImage()).thenReturn(fakeImage);
+
+        ImageController controller = new ImageController(mockService);
+        ResponseEntity<?> response = controller.getImage(null);
+
+        assertNotNull(response);
+        assertArrayEquals(fakeImage, (byte[]) response.getBody());
+        verify(mockService).fetchImage();
+    }
+
+    @Test
+    public void testGetImageWithLocation() {
+        ImageService mockService = mock(ImageService.class);
+        byte[] fakeImage = new byte[]{40, 50, 60};
+        when(mockService.fetchImage("asia")).thenReturn(fakeImage);
+
+        ImageController controller = new ImageController(mockService);
+        ResponseEntity<?> response = controller.getImage("asia");
+
+        assertNotNull(response);
+        assertArrayEquals(fakeImage, (byte[]) response.getBody());
+        verify(mockService).fetchImage("asia");
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs25/controller/ImageControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs25/controller/ImageControllerTest.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs25.controller;
 
 import ch.uzh.ifi.hase.soprafs25.service.image.ImageService;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
 
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -15,7 +16,8 @@ public class ImageControllerTest {
         when(mockService.fetchImage()).thenReturn(fakeImage);
 
         ImageController controller = new ImageController(mockService);
-        byte[] response = controller.getImage();
+        ResponseEntity<?> responseEntity = controller.getImage(null);
+        byte[] response = (byte[]) responseEntity.getBody();
 
         assertArrayEquals(fakeImage, response);
         verify(mockService).fetchImage();


### PR DESCRIPTION
**Summary**
- Extended ImageService with fetchImage(String location)
- Implemented method in MockImageService and GoogleImageService
- Added coordinates.json for bounding box data
- Updated ImageController to use new method when location is provided
- Added unit tests to verify both with and without location
