### PR TITLE
69 assign google view street view images to the specific round

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/controller/ImageController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/controller/ImageController.java
@@ -9,6 +9,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+import ch.uzh.ifi.hase.soprafs25.entity.Game;
+import ch.uzh.ifi.hase.soprafs25.session.GameSessionManager;
 
 @RestController
 public class ImageController {
@@ -28,5 +31,14 @@ public class ImageController {
                 : imageService.fetchImageByLocation(location);
         return ResponseEntity.ok(image);
     }
+
+    @GetMapping(value = "/image/{roomCode}/{index}", produces = MediaType.IMAGE_JPEG_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    public byte[] getGameImage(@PathVariable String roomCode, @PathVariable int index) {
+        Game game = GameSessionManager.getGameSession(roomCode);
+        return game.getImages().get(index);
+    }
+
+
 }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/GameService.java
@@ -119,6 +119,8 @@ public class GameService {
         return GameSessionManager.getGameSession(roomCode);
     }
 
+    @SuppressWarnings("unused")
     public void createGame(String code) {
+        // TODO: implement this method when game creation logic is ready
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/GameService.java
@@ -5,9 +5,8 @@ import ch.uzh.ifi.hase.soprafs25.constant.PlayerRole;
 import ch.uzh.ifi.hase.soprafs25.entity.Game;
 import ch.uzh.ifi.hase.soprafs25.model.GameSettingsDTO;
 import ch.uzh.ifi.hase.soprafs25.service.image.ImageService;
-import ch.uzh.ifi.hase.soprafs25.service.image.MockImageService;
 import ch.uzh.ifi.hase.soprafs25.session.GameSessionManager;
-import org.mapstruct.Qualifier;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -43,7 +42,7 @@ public class GameService {
         advancePhase(roomCode, GamePhase.GAME);
         game.assignRoles(gameReadService.getNicknamesInRoom(roomCode));
         game.setHighlightedImageIndex(RANDOM.nextInt(game.getGameSettings().getImageCount()));
-        prepareImagesForRound();
+        prepareImagesForRound(game);
     }
 
     public void advancePhase(String roomCode, GamePhase newPhase) {
@@ -112,9 +111,14 @@ public class GameService {
             byte[] img = imageService.fetchImageByLocation(game.getGameSettings().getImageRegion());
             imageList.add(img);
         }
+
+        game.setImages(imageList);
     }
 
     private Game getGame(String roomCode) {
         return GameSessionManager.getGameSession(roomCode);
+    }
+
+    public void createGame(String code) {
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/GameService.java
@@ -4,9 +4,14 @@ import ch.uzh.ifi.hase.soprafs25.constant.GamePhase;
 import ch.uzh.ifi.hase.soprafs25.constant.PlayerRole;
 import ch.uzh.ifi.hase.soprafs25.entity.Game;
 import ch.uzh.ifi.hase.soprafs25.model.GameSettingsDTO;
+import ch.uzh.ifi.hase.soprafs25.service.image.ImageService;
+import ch.uzh.ifi.hase.soprafs25.service.image.MockImageService;
 import ch.uzh.ifi.hase.soprafs25.session.GameSessionManager;
+import org.mapstruct.Qualifier;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 @Service
@@ -17,13 +22,16 @@ public class GameService {
     private final AuthorizationService authorizationService;
     private final GameReadService gameReadService;
     private final GameBroadcastService gameBroadcastService;
+    private final ImageService imageService;
 
     public GameService(AuthorizationService authorizationService,
                        GameReadService gameReadService,
-                       GameBroadcastService gameBroadcastService) {
+                       GameBroadcastService gameBroadcastService,
+                       @Qualifier("mockImageService") ImageService mockImageService) {
         this.authorizationService = authorizationService;
         this.gameReadService = gameReadService;
         this.gameBroadcastService = gameBroadcastService;
+        this.imageService = mockImageService;
     }
 
     public void startRound(String roomCode, String nickname) {
@@ -94,8 +102,16 @@ public class GameService {
         return game.getHighlightedImageIndex() == spyGuessIndex;
     }
 
-    private void prepareImagesForRound() {
-        // ToDo: Assign images to the game object if missing, return the existing otherwise
+    private void prepareImagesForRound(Game game) {
+        if(!game.getImages().isEmpty()) {
+            return;
+        }
+
+        List<byte[]> imageList = new ArrayList<>();
+        for(int i = 0; i < game.getGameSettings().getImageCount(); i++) {
+            byte[] img = imageService.fetchImageByLocation(game.getGameSettings().getImageRegion());
+            imageList.add(img);
+        }
     }
 
     private Game getGame(String roomCode) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs25/controller/ImageControllerByIndexTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs25/controller/ImageControllerByIndexTest.java
@@ -35,15 +35,14 @@ class ImageControllerByIndexTest {
 
     @Test
     void testGetGameImage_invalidIndex_throwsException() {
-        assertThrows(IndexOutOfBoundsException.class, () -> {
-            imageController.getGameImage("ROOM1", 99);
-        });
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> imageController.getGameImage("ROOM1", 99));
     }
 
     @Test
     void testGetGameImage_invalidRoom_throwsException() {
-        assertThrows(IllegalStateException.class, () -> {
-            imageController.getGameImage("NON_EXISTENT", 0);
-        });
+        assertThrows(IllegalStateException.class,
+                () -> imageController.getGameImage("NON_EXISTENT", 0));
     }
+
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs25/controller/ImageControllerByIndexTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs25/controller/ImageControllerByIndexTest.java
@@ -1,0 +1,49 @@
+package ch.uzh.ifi.hase.soprafs25.controller;
+
+import ch.uzh.ifi.hase.soprafs25.entity.Game;
+import ch.uzh.ifi.hase.soprafs25.session.GameSessionManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ImageControllerByIndexTest {
+
+    private ImageController imageController;
+
+    @BeforeEach
+    void setUp() {
+        imageController = new ImageController(null);
+
+        Game game = new Game("ROOM1");
+        game.setImages(List.of(
+                new byte[]{10, 20},
+                new byte[]{30, 40},
+                new byte[]{50, 60}
+        ));
+        GameSessionManager.addGameSession(game);
+    }
+
+    @Test
+    void testGetGameImage_validIndex_returnsImage() {
+        byte[] result = imageController.getGameImage("ROOM1", 1);
+        assertNotNull(result);
+        assertArrayEquals(new byte[]{30, 40}, result);
+    }
+
+    @Test
+    void testGetGameImage_invalidIndex_throwsException() {
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            imageController.getGameImage("ROOM1", 99);
+        });
+    }
+
+    @Test
+    void testGetGameImage_invalidRoom_throwsException() {
+        assertThrows(IllegalStateException.class, () -> {
+            imageController.getGameImage("NON_EXISTENT", 0);
+        });
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs25/service/CreateRoomServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs25/service/CreateRoomServiceTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.*;
 
 import org.mockito.junit.jupiter.MockitoExtension;
 
-
 @ExtendWith(MockitoExtension.class)
 class CreateRoomServiceTest {
 
@@ -20,6 +19,9 @@ class CreateRoomServiceTest {
 
     @Mock
     private JoinRoomService joinRoomService;
+
+    @Mock
+    private GameService gameService;
 
     @InjectMocks
     private CreateRoomService createRoomService;
@@ -40,10 +42,13 @@ class CreateRoomServiceTest {
         when(roomRepository.save(any(Room.class))).thenReturn(room);
         when(joinRoomService.joinRoom(eq("ROOM1"), any(Player.class))).thenReturn(joinedPlayer);
 
+        doNothing().when(gameService).createGame("ROOM1");
+
         Player result = createRoomService.createRoom(player);
 
         assertEquals("TestUser", result.getNickname());
         verify(roomRepository, times(2)).save(any(Room.class));
         verify(joinRoomService).joinRoom("ROOM1", player);
+        verify(gameService).createGame("ROOM1"); // ✅ kontrol
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs25/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs25/service/GameServiceTest.java
@@ -1,0 +1,63 @@
+package ch.uzh.ifi.hase.soprafs25.service;
+
+import ch.uzh.ifi.hase.soprafs25.entity.Game;
+import ch.uzh.ifi.hase.soprafs25.service.image.ImageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class GameServiceTest {
+
+    @Mock
+    private AuthorizationService authorizationService;
+
+    @Mock
+    private GameReadService gameReadService;
+
+    @Mock
+    private GameBroadcastService gameBroadcastService;
+
+    @Mock
+    private ImageService imageService;
+
+    @InjectMocks
+    private GameService gameService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        gameService = new GameService(authorizationService, gameReadService, gameBroadcastService, imageService);
+    }
+
+    @Test
+    void testPrepareImagesForRound_addsImagesCorrectly() {
+        // given
+        Game game = new Game("ROOM123");
+        game.setGameSettings(1, 30, 3, "europe");
+
+        byte[] mockImage = new byte[]{1, 2, 3};
+        when(imageService.fetchImageByLocation("europe")).thenReturn(mockImage);
+
+        // when
+        Method method = ReflectionUtils.findMethod(GameService.class, "prepareImagesForRound", Game.class);
+        assertNotNull(method, "Method 'prepareImagesForRound' should exist");
+        method.setAccessible(true);
+        ReflectionUtils.invokeMethod(method, gameService, game);
+
+        // then
+        List<byte[]> images = game.getImages();
+        assertEquals(3, images.size(), "There should be 3 images loaded");
+        for (byte[] image : images) {
+            assertArrayEquals(mockImage, image, "Image bytes should match mock result");
+        }
+
+        verify(imageService, times(3)).fetchImageByLocation("europe");
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs25/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs25/service/GameServiceTest.java
@@ -32,12 +32,17 @@ class GameServiceTest {
 
     @BeforeEach
     void setUp() {
-        try (AutoCloseable mocks = MockitoAnnotations.openMocks(this)) {
-            gameService = new GameService(authorizationService, gameReadService, gameBroadcastService, imageService);
+        AutoCloseable mocks = MockitoAnnotations.openMocks(this);
+        gameService = new GameService(authorizationService, gameReadService, gameBroadcastService, imageService);
+
+        try {
+            mocks.close();
         } catch (Exception e) {
-            fail("Failed to initialize mocks: " + e.getMessage());
+            fail("Failed to close mocks: " + e.getMessage());
         }
     }
+
+
 
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs25/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs25/service/GameServiceTest.java
@@ -32,9 +32,13 @@ class GameServiceTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
-        gameService = new GameService(authorizationService, gameReadService, gameBroadcastService, imageService);
+        try (AutoCloseable mocks = MockitoAnnotations.openMocks(this)) {
+            gameService = new GameService(authorizationService, gameReadService, gameBroadcastService, imageService);
+        } catch (Exception e) {
+            fail("Failed to initialize mocks: " + e.getMessage());
+        }
     }
+
 
     @Test
     void testPrepareImagesForRound_addsImagesCorrectly() {


### PR DESCRIPTION
**Summary**
- added logic to persist images in Game entity after fetching (GameService#prepareImagesForRound)
- introduced new REST endpoint /image/{roomCode}/{index} in ImageController to retrieve room-based images
- improved dependency injection by specifying mockImageService qualifier in GameService
- added corresponding unit tests for both service and controller layers
- applied minor code style cleanups and SonarQube suggestions
